### PR TITLE
Fix unpickling2

### DIFF
--- a/examples/styletransfer/Art Style Transfer.ipynb
+++ b/examples/styletransfer/Art Style Transfer.ipynb
@@ -136,7 +136,7 @@
     "\n",
     "net = build_model()\n",
     "\n",
-    "values = pickle.load(open('vgg19_normalized.pkl'))['param values']\n",
+    "values = pickle.load(open('vgg19_normalized.pkl','rb'),encoding='latin-1')['param values']\n",
     "lasagne.layers.set_all_param_values(net['pool5'], values)"
    ]
   },


### PR DESCRIPTION
UnicodeDecodeError would be thrown if the file is open()ed without byte mode or if no coding is passed to pickle.load.
